### PR TITLE
ci: bump to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ defaults:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
 
     steps:
@@ -58,7 +58,7 @@ jobs:
           deno fmt --check
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     needs:
       - lint
@@ -90,7 +90,7 @@ jobs:
           retention-days: 1
 
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     needs:
       - build

--- a/.github/workflows/deps-automerge.yml
+++ b/.github/workflows/deps-automerge.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   automerge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'loozhengyuan' }}
 


### PR DESCRIPTION
This commit updates the repositories to use `ubuntu-24.04` runner type.

Idempotency-Key: b65e24792f1426145cd7e87ec4b34af8f1f8997b122f0173c1f5dc88a97e9c97
